### PR TITLE
nagios_plugins: Fix false OKs on help text

### DIFF
--- a/nagios_plugins/check_proc_cpu/check_proc_cpu.sh
+++ b/nagios_plugins/check_proc_cpu/check_proc_cpu.sh
@@ -61,6 +61,6 @@ else
     echo "check_proc_cpu.sh -w 200 -c 400 --cmdpattern \"tomcat7.*java.*Dcom\""
     echo ""
     echo "Copyright (C) 2015 DennyZhang (contact@dennyzhang.com)"
-    exit
+    exit 3
 fi
 ## File - check_proc_cpu.sh ends

--- a/nagios_plugins/check_proc_fd/check_proc_fd.sh
+++ b/nagios_plugins/check_proc_fd/check_proc_fd.sh
@@ -62,6 +62,6 @@ else
     echo "check_proc_fd.sh -w 1024 -c 2048 --cmdpattern \"tomcat7.*java.*MaxPermSize\""
     echo ""
     echo "Copyright (C) 2014 DennyZhang (contact@dennyzhang.com)"
-    exit
+    exit 3
 fi
 ## File - check_proc_fd.sh ends

--- a/nagios_plugins/check_proc_mem/check_proc_mem.sh
+++ b/nagios_plugins/check_proc_mem/check_proc_mem.sh
@@ -65,6 +65,6 @@ else
     echo "check_proc_mem.sh -w 1024 -c 2048 --cmdpattern \"tomcat7.*java.*Dcom\""
     echo ""
     echo "Copyright (C) 2014 DennyZhang (contact@dennyzhang.com)"
-    exit
+    exit 3
 fi
 ## File - check_proc_mem.sh ends

--- a/nagios_plugins/check_proc_threadcount/check_proc_threadcount.sh
+++ b/nagios_plugins/check_proc_threadcount/check_proc_threadcount.sh
@@ -54,6 +54,6 @@ else
     echo "check_proc_threadcount.sh -w 1024 -c 2048 --cmdpattern \"tomcat7.*java.*MaxPermSize\""
     echo ""
     echo "Copyright (C) 2017 DennyZhang (contact@dennyzhang.com)"
-    exit
+    exit 3
 fi
 ## File - check_proc_threadcount.sh ends


### PR DESCRIPTION
This patch fixes getting false OK from scripts when it is actually not run
correctly but printing help text to help the user.  Now it returns UNKNOWN
which is more appropriate when this happens.